### PR TITLE
Refactoring of exception handling, errors, and skips

### DIFF
--- a/src/main/java/io/anserini/collection/CarCollection.java
+++ b/src/main/java/io/anserini/collection/CarCollection.java
@@ -54,7 +54,7 @@ public class CarCollection extends DocumentCollection<CarCollection.Document> {
     }
 
     @Override
-    public void readNext() throws IOException {
+    public void readNext() {
       System.setProperty("file.encoding", "UTF-8");
       Data.Paragraph p;
       p = iter.next();

--- a/src/main/java/io/anserini/collection/ClueWeb09Collection.java
+++ b/src/main/java/io/anserini/collection/ClueWeb09Collection.java
@@ -121,13 +121,8 @@ public class ClueWeb09Collection extends DocumentCollection<ClueWeb09Collection.
     }
 
     @Override
-    public void readNext() throws IOException {
-      try {
-        bufferedRecord = readNextWarcRecord(stream, Document.WARC_VERSION);
-      } catch (IOException e1){
-        nextRecordStatus = Status.ERROR;
-        throw e1;
-      }
+    public void readNext() throws IOException, NoSuchElementException {
+      bufferedRecord = readNextWarcRecord(stream, Document.WARC_VERSION);
     }
 
     @Override

--- a/src/main/java/io/anserini/collection/ClueWeb12Collection.java
+++ b/src/main/java/io/anserini/collection/ClueWeb12Collection.java
@@ -112,13 +112,8 @@ public class ClueWeb12Collection extends DocumentCollection<ClueWeb12Collection.
     }
 
     @Override
-    public void readNext() throws IOException {
-      try {
-        bufferedRecord = readNextWarcRecord(stream, Document.WARC_VERSION);
-      } catch (IOException e1){
-        nextRecordStatus = Status.ERROR;
-        throw e1;
-      }
+    public void readNext() throws IOException, NoSuchElementException {
+      bufferedRecord = readNextWarcRecord(stream, Document.WARC_VERSION);
     }
 
     @Override

--- a/src/main/java/io/anserini/collection/ClueWeb12Collection.java
+++ b/src/main/java/io/anserini/collection/ClueWeb12Collection.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
+import java.util.NoSuchElementException;
 
 /**
  * An instance of the <a href="https://www.lemurproject.org/clueweb12.php/">ClueWeb12 collection</a>.

--- a/src/main/java/io/anserini/collection/FileSegment.java
+++ b/src/main/java/io/anserini/collection/FileSegment.java
@@ -30,16 +30,11 @@ import java.util.Iterator;
  */
 public abstract class FileSegment<T extends SourceDocument> implements Iterable<T> {
 
-  public enum Status {
-    SKIPPED, ERROR, VOID
-  }
-
   protected Path path;
   protected final int BUFFER_SIZE = 1 << 16; // 64K
   protected BufferedReader bufferedReader;
   protected boolean atEOF = false;
   protected T bufferedRecord = null;
-  protected Status nextRecordStatus = Status.VOID;
 
   /**
    * Move exception handling for skipped docs to within segment
@@ -47,6 +42,13 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
    * Call getSkippedCount() at the end of segment iteration to return count of total docs skipped
    */
   protected int skipped = 0;
+
+  /**
+   * Move exception handling for file read errors to within segment
+   * Desired behaviour is to stop iteration and update error = true
+   * Call getErrorStatus() at the end of segment iteration to return error status of iterator
+   */
+  protected boolean error = false;
 
   public FileSegment(Path segmentPath) {
     this.path = segmentPath;
@@ -56,18 +58,17 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
     return skipped;
   }
 
-  public final Path getSegmentPath() {
-    return path;
+  public final boolean getErrorStatus() {
+    return error;
   }
 
-  public final Status getNextRecordStatus() {
-    return nextRecordStatus;
+  public final Path getSegmentPath() {
+    return path;
   }
 
   public void close() throws IOException {
     atEOF = true;
     bufferedRecord = null;
-    nextRecordStatus = Status.VOID;
     if (bufferedReader != null) {
       bufferedReader.close();
     }
@@ -79,7 +80,7 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
    * @throws IOException if reader error encountered
    */
 
-  protected abstract void readNext() throws IOException;
+  protected abstract void readNext() throws IOException, NoSuchElementException;
 
   /**
    * An iterator over {@code SourceDocument} for the {@code FileSegment} iterable.
@@ -92,8 +93,11 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
 
       @Override
       public T next() throws NoSuchElementException {
-        if (nextRecordStatus == Status.ERROR || bufferedRecord == null && !hasNext()) {
-          nextRecordStatus = Status.VOID;
+//        if (nextRecordStatus == Status.ERROR || bufferedRecord == null && !hasNext()) {
+        if (error) {
+          throw new NoSuchElementException("Encountered file read error, stopping iteration.");
+        }
+        if (bufferedRecord == null && !hasNext()) {
           throw new NoSuchElementException("EOF has been reached. No more documents to read.");
         }
         T ret = bufferedRecord;
@@ -103,9 +107,6 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
 
       @Override
       public boolean hasNext() {
-        if (nextRecordStatus == Status.ERROR) {
-          return false;
-        }
 
         if (bufferedRecord != null) {
           return true;
@@ -115,14 +116,17 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
 
         try {
           readNext();
-        } catch (IOException | NoSuchElementException e1) {
-          // Exceptions where expected behaviour is to stop iteration
-          // For IOException, nextRecordStatus = Status.ERROR should be handled in readNext() depending on collection
+        } catch (IOException e1) {
+          // Error, stop iteration
+          // Call getErrorStatus() at the end of segment iteration and update error counter
+          error = true;
           return false;
-        } catch (RuntimeException e2) {
-          // Exceptions where expected behaviour is to skip and continue iteration
-          // Call getSkippedCount() at the end of segment iteration to return count of total docs skipped
-          nextRecordStatus = Status.VOID;
+        } catch (NoSuchElementException e2){
+          // EOF, stop iteration
+          return false;
+        } catch (RuntimeException e3) {
+          // Skip and continue iteration
+          // Call getSkippedCount() at the end of segment iteration and update skipped counter
           skipped += 1;
           return hasNext();
         }

--- a/src/main/java/io/anserini/collection/FileSegment.java
+++ b/src/main/java/io/anserini/collection/FileSegment.java
@@ -19,6 +19,7 @@ package io.anserini.collection;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.text.ParseException;
 import java.util.NoSuchElementException;
 import java.util.Iterator;
 
@@ -81,7 +82,7 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
    * @throws NoSuchElementException if EOF encountered
    */
 
-  protected abstract void readNext() throws IOException, NoSuchElementException;
+  protected abstract void readNext() throws IOException, ParseException, NoSuchElementException;
 
   /**
    * An iterator over {@code SourceDocument} for the {@code FileSegment} iterable.
@@ -125,7 +126,7 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
         } catch (NoSuchElementException e2){
           // EOF, stop iteration
           return false;
-        } catch (RuntimeException e3) {
+        } catch (ParseException e3) {
           // Skip and continue iteration
           // Call getSkippedCount() at the end of segment iteration and update skipped counter
           skipped += 1;

--- a/src/main/java/io/anserini/collection/FileSegment.java
+++ b/src/main/java/io/anserini/collection/FileSegment.java
@@ -78,6 +78,7 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
    * For concrete classes to implement depending on desired iterator behaviour
    *
    * @throws IOException if reader error encountered
+   * @throws NoSuchElementException if EOF encountered
    */
 
   protected abstract void readNext() throws IOException, NoSuchElementException;

--- a/src/main/java/io/anserini/collection/FileSegment.java
+++ b/src/main/java/io/anserini/collection/FileSegment.java
@@ -78,8 +78,9 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
   /**
    * For concrete classes to implement depending on desired iterator behaviour
    *
-   * @throws IOException if reader error encountered
-   * @throws NoSuchElementException if EOF encountered
+   * @throws IOException if reader error encountered and iterator should stop
+   * @throws ParseException if parse error encountered and iterator should continue
+   * @throws NoSuchElementException if EOF encountered and iterator should stop
    */
 
   protected abstract void readNext() throws IOException, ParseException, NoSuchElementException;
@@ -95,7 +96,6 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
 
       @Override
       public T next() throws NoSuchElementException {
-//        if (nextRecordStatus == Status.ERROR || bufferedRecord == null && !hasNext()) {
         if (error) {
           throw new NoSuchElementException("Encountered file read error, stopping iteration.");
         }

--- a/src/main/java/io/anserini/collection/HtmlCollection.java
+++ b/src/main/java/io/anserini/collection/HtmlCollection.java
@@ -72,8 +72,8 @@ public class HtmlCollection extends DocumentCollection<HtmlCollection.Document> 
           atEOF = true;
         }
       } catch (IOException e1) {
-        if (!path.toString().endsWith(".xml")) {
-          nextRecordStatus = Status.ERROR;
+        if (path.toString().endsWith(".html")) {
+          atEOF = true;
         }
         throw e1;
       }

--- a/src/main/java/io/anserini/collection/JsonCollection.java
+++ b/src/main/java/io/anserini/collection/JsonCollection.java
@@ -98,7 +98,7 @@ public class JsonCollection extends DocumentCollection<JsonCollection.Document> 
     }
 
     @Override
-    public void readNext() throws IOException {
+    public void readNext() throws NoSuchElementException {
       if (node == null) {
         throw new NoSuchElementException("JsonNode is empty");
       } else if (node.isObject()) {

--- a/src/main/java/io/anserini/collection/NewYorkTimesCollection.java
+++ b/src/main/java/io/anserini/collection/NewYorkTimesCollection.java
@@ -92,7 +92,7 @@ public class NewYorkTimesCollection extends DocumentCollection<NewYorkTimesColle
     }
 
     @Override
-    protected void readNext() throws IOException {
+    protected void readNext() throws IOException, NoSuchElementException {
       try {
         if (path.toString().endsWith(".tgz")) {
           getNextEntry();
@@ -105,8 +105,8 @@ public class NewYorkTimesCollection extends DocumentCollection<NewYorkTimesColle
           atEOF = true; // if it is a xml file, the segment only has one file, boolean to keep track if it's been read.
         }
       } catch (IOException e1) {
-        if (!path.toString().endsWith(".xml")) {
-          nextRecordStatus = Status.ERROR;
+        if (path.toString().endsWith(".xml")) {
+          atEOF = true;
         }
         throw e1;
       }

--- a/src/main/java/io/anserini/collection/TrecCollection.java
+++ b/src/main/java/io/anserini/collection/TrecCollection.java
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
+import java.text.ParseException;
 
 /**
  * A classic TREC <i>ad hoc</i> document collection.
@@ -80,7 +81,7 @@ public class TrecCollection extends DocumentCollection<TrecCollection.Document> 
     }
 
     @Override
-    public void readNext() throws IOException {
+    public void readNext() throws IOException, ParseException {
         readNextRecord(bufferedReader);
     }
 

--- a/src/main/java/io/anserini/collection/TrecCollection.java
+++ b/src/main/java/io/anserini/collection/TrecCollection.java
@@ -81,12 +81,7 @@ public class TrecCollection extends DocumentCollection<TrecCollection.Document> 
 
     @Override
     public void readNext() throws IOException {
-      try {
         readNextRecord(bufferedReader);
-      } catch (IOException e1) {
-        nextRecordStatus = Status.ERROR;
-        throw e1;
-      }
     }
 
     private void readNextRecord(BufferedReader reader) throws IOException {

--- a/src/main/java/io/anserini/collection/TrecwebCollection.java
+++ b/src/main/java/io/anserini/collection/TrecwebCollection.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.text.ParseException;
 import java.util.List;
 
 /**
@@ -48,11 +49,11 @@ public class TrecwebCollection extends DocumentCollection<TrecwebCollection.Docu
     }
 
     @Override
-    public void readNext() throws IOException {
+    public void readNext() throws IOException, ParseException {
         readNextRecord(bufferedReader);
     }
 
-    private void readNextRecord(BufferedReader reader) throws IOException {
+    private void readNextRecord(BufferedReader reader) throws IOException, ParseException {
       StringBuilder builder = new StringBuilder();
       boolean found = false;
 
@@ -76,25 +77,25 @@ public class TrecwebCollection extends DocumentCollection<TrecwebCollection.Docu
     }
 
     @SuppressWarnings("unchecked")
-    private void parseRecord(StringBuilder builder) {
+    private void parseRecord(StringBuilder builder) throws ParseException {
       int i = builder.indexOf(Document.DOCNO);
-      if (i == -1) throw new RuntimeException("cannot find start tag " + Document.DOCNO);
+      if (i == -1) throw new ParseException("cannot find start tag " + Document.DOCNO, 0);
 
-      if (i != 0) throw new RuntimeException("should start with " + Document.DOCNO);
+      if (i != 0) throw new ParseException("should start with " + Document.DOCNO, 0);
 
       int j = builder.indexOf(Document.TERMINATING_DOCNO);
-      if (j == -1) throw new RuntimeException("cannot find end tag " + Document.TERMINATING_DOCNO);
+      if (j == -1) throw new ParseException("cannot find end tag " + Document.TERMINATING_DOCNO, 0);
 
       bufferedRecord = (T) new Document();
       bufferedRecord.id = builder.substring(i + Document.DOCNO.length(), j).trim();
 
       i = builder.indexOf(Document.DOCHDR);
-      if (i == -1) throw new RuntimeException("cannot find header tag " + Document.DOCHDR);
+      if (i == -1) throw new ParseException("cannot find header tag " + Document.DOCHDR, 0);
 
       j = builder.indexOf(Document.TERMINATING_DOCHDR);
-      if (j == -1) throw new RuntimeException("cannot find end tag " + Document.TERMINATING_DOCHDR);
+      if (j == -1) throw new ParseException("cannot find end tag " + Document.TERMINATING_DOCHDR, 0);
 
-      if (j < i) throw new RuntimeException(Document.TERMINATING_DOCHDR + " comes before " + Document.DOCHDR);
+      if (j < i) throw new ParseException(Document.TERMINATING_DOCHDR + " comes before " + Document.DOCHDR, 0);
 
       bufferedRecord.content = builder.substring(j + Document.TERMINATING_DOCHDR.length()).trim();
     }

--- a/src/main/java/io/anserini/collection/TrecwebCollection.java
+++ b/src/main/java/io/anserini/collection/TrecwebCollection.java
@@ -49,12 +49,7 @@ public class TrecwebCollection extends DocumentCollection<TrecwebCollection.Docu
 
     @Override
     public void readNext() throws IOException {
-      try {
         readNextRecord(bufferedReader);
-      } catch (IOException e1) {
-        nextRecordStatus = Status.ERROR;
-        throw e1;
-      }
     }
 
     private void readNextRecord(BufferedReader reader) throws IOException {

--- a/src/main/java/io/anserini/collection/TweetCollection.java
+++ b/src/main/java/io/anserini/collection/TweetCollection.java
@@ -77,7 +77,7 @@ public class TweetCollection extends DocumentCollection<TweetCollection.Document
     }
 
     @Override
-    public void readNext() throws IOException {
+    public void readNext() throws IOException, NoSuchElementException, ParseException {
       String nextRecord = bufferedReader.readLine();
       if (nextRecord == null) {
         throw new NoSuchElementException();
@@ -85,7 +85,7 @@ public class TweetCollection extends DocumentCollection<TweetCollection.Document
       parseJson(nextRecord);
     }
 
-    private void parseJson(String json) {
+    private void parseJson(String json) throws ParseException {
       ObjectMapper mapper = new ObjectMapper();
       Document.TweetObject tweetObj = null;
       try {
@@ -94,11 +94,11 @@ public class TweetCollection extends DocumentCollection<TweetCollection.Document
                 .registerModule(new Jdk8Module()) // Deserialize Java 8 Optional: http://www.baeldung.com/jackson-optional
                 .readValue(json, Document.TweetObject.class);
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        throw new ParseException("IOException in parseJson", 0);
       }
 
       if (JsonParser.isFieldAvailable(tweetObj.getDelete())) {
-        throw new RuntimeException("Ignore deleted tweets");
+        throw new ParseException("Ignore deleted tweets", 0);
       }
 
       bufferedRecord = new TweetCollection.Document();
@@ -113,7 +113,7 @@ public class TweetCollection extends DocumentCollection<TweetCollection.Document
       } catch (ParseException e) {
         bufferedRecord.timestampMs = OptionalLong.of(-1L);
         bufferedRecord.epoch = OptionalLong.of(-1L);
-        throw new RuntimeException(e);
+        throw e;
       }
 
       if (JsonParser.isFieldAvailable(tweetObj.getInReplyToStatusId())) {

--- a/src/main/java/io/anserini/collection/TweetCollection.java
+++ b/src/main/java/io/anserini/collection/TweetCollection.java
@@ -78,16 +78,11 @@ public class TweetCollection extends DocumentCollection<TweetCollection.Document
 
     @Override
     public void readNext() throws IOException {
-      try {
-        String nextRecord = bufferedReader.readLine();
-        if (nextRecord == null) {
-          throw new NoSuchElementException();
-        }
-        parseJson(nextRecord);
-      } catch (IOException e1) {
-        nextRecordStatus = Status.ERROR;
-        throw e1;
+      String nextRecord = bufferedReader.readLine();
+      if (nextRecord == null) {
+        throw new NoSuchElementException();
       }
+      parseJson(nextRecord);
     }
 
     private void parseJson(String json) {

--- a/src/main/java/io/anserini/collection/WashingtonPostCollection.java
+++ b/src/main/java/io/anserini/collection/WashingtonPostCollection.java
@@ -72,16 +72,11 @@ public class WashingtonPostCollection extends DocumentCollection<WashingtonPostC
 
     @Override
     public void readNext() throws IOException {
-      try {
-        String nextRecord = bufferedReader.readLine();
-        if (nextRecord == null) {
-          throw new NoSuchElementException();
-        }
-        parseRecord(nextRecord);
-      } catch (IOException e1) {
-        nextRecordStatus = Status.ERROR;
-        throw e1;
+      String nextRecord = bufferedReader.readLine();
+      if (nextRecord == null) {
+        throw new NoSuchElementException();
       }
+      parseRecord(nextRecord);
     }
 
     private void parseRecord(String record) {

--- a/src/main/java/io/anserini/collection/WikipediaCollection.java
+++ b/src/main/java/io/anserini/collection/WikipediaCollection.java
@@ -62,7 +62,7 @@ public class WikipediaCollection extends DocumentCollection<WikipediaCollection.
     }
 
     @Override
-    public void readNext() throws IOException {
+    public void readNext() {
       String page;
       String s;
 

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -289,7 +289,7 @@ public final class IndexCollection {
                   " docs skipped.");
         }
 
-        if (segment.getNextRecordStatus() == FileSegment.Status.ERROR) {
+        if (segment.getErrorStatus()) {
           counters.errors.incrementAndGet();
         }
 
@@ -386,7 +386,7 @@ public final class IndexCollection {
           flush();
         }
 
-        if (segment.getNextRecordStatus() == FileSegment.Status.ERROR) {
+        if (segment.getErrorStatus()) {
           counters.errors.incrementAndGet();
         }
 


### PR DESCRIPTION
* `readNext()` throws three types of exceptions caught in `hasNext()`: `IOException` (error), `NoSuchElementException` (EOF), and `ParseException` (skip)
* Each segment keeps count of whether error occurred (iteration stopped) as well as number of skips (iteration continued)